### PR TITLE
askSpeedQuiz functionality

### DIFF
--- a/src/main/java/moe/maple/api/script/logic/ScriptAPI.java
+++ b/src/main/java/moe/maple/api/script/logic/ScriptAPI.java
@@ -686,13 +686,13 @@ public enum ScriptAPI {
         return askSpeedQuiz(script, script.getSpeakerTemplateId(), 0, type, answer, correct, remaining, remainInitialQuiz, "", "", "", 0, 0);
     }
 
-    public static StringActionChain askSpeedQuiz(MoeScript script) {//force close the window
+    public static StringActionChain askSpeedQuiz(MoeScript script) { //force the user's speedQuiz window to close
         return askSpeedQuiz(script, script.getSpeakerTemplateId(), 1, 0, 0, 0,0, 0, "", "", "", 0, 0);
     }
 
     public static StringActionChain askSpeedQuiz(MoeScript script, int speakerTemplateId, int param, int type, int answer, int correct, int remaining, int remainInitialQuiz, String title, String problemText, String hintText, int min, int max) {
         script.setScriptAction(null);
-        if (param == 0) script.setScriptResponse(askSpeedQuizResponse(script, answer));//param 1 = force close the window
+        if (param == 0) script.setScriptResponse(askSpeedQuizResponse(script, answer)); //param 1 = force close the window
         script.getUserObject().ifPresentOrElse(obj -> ScriptAPI.INSTANCE.messengerAskSpeedQuiz.send(obj, speakerTemplateId, param, type, answer, correct, remaining, remainInitialQuiz, title, problemText, hintText, (short)min, (short)max),
                 () -> log.debug("User object isn't set, workflow is messy."));
         return script::setScriptAction;
@@ -700,8 +700,8 @@ public enum ScriptAPI {
 
     private static ScriptResponse askSpeedQuizResponse(MoeScript script, int answer) {
         return (t, a, o) -> {
-            var response = (String)o;
-            var bad = response == null;
+            var response = (String)o; //client sends strings instead of actions. GIVE UP button -> "__GIVEUP__", NEXT button -> "", OK button (or enter) -> answer
+            var bad = response == null; //your askSpeedQuiz packet handler should only decode type and object (string). action is not used at all in speedQuiz
             var real = ScriptAPI.INSTANCE.getScriptMessageType(ScriptMessageType.ASKSPEEDQUIZ);
 
             if (t.intValue() != real || bad) {

--- a/src/main/java/moe/maple/api/script/model/SpeakingScript.java
+++ b/src/main/java/moe/maple/api/script/model/SpeakingScript.java
@@ -303,7 +303,7 @@ public interface SpeakingScript extends MessagingScript {
         return ScriptAPI.askSpeedQuiz(this, type, answer, correct, remaining, remainInitialQuiz);
     }
 
-    default StringActionChain endSpeedQuiz() {
+    default StringActionChain endSpeedQuiz() { //force the user's speedQuiz window to close
         return ScriptAPI.askSpeedQuiz(this);
     }
 

--- a/src/main/java/moe/maple/api/script/model/SpeakingScript.java
+++ b/src/main/java/moe/maple/api/script/model/SpeakingScript.java
@@ -35,10 +35,8 @@ import moe.maple.api.script.util.Moematter;
 import moe.maple.api.script.util.builder.SayBuilder;
 import moe.maple.api.script.util.tuple.Tuple;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * This should mainly be implemented by NPCs
@@ -54,7 +52,7 @@ public interface SpeakingScript extends MessagingScript {
     }
 
     default void exchange(BasicScriptAction onTrue, String onFalseMessage, int money, int... itemIdAndCount) {
-        exchange(onTrue, ()-> say(onFalseMessage), money, itemIdAndCount);
+        exchange(onTrue, () -> say(onFalseMessage), money, itemIdAndCount);
     }
 
     default void exchange(BasicScriptAction onFalse, int money, int itemId, int itemCount) {
@@ -74,7 +72,7 @@ public interface SpeakingScript extends MessagingScript {
     }
 
     default void exchange(BasicScriptAction onFalse, Exchange exchange) {
-        exchange(() -> { }, onFalse,  exchange);
+        exchange(() -> {}, onFalse, exchange);
     }
 
     default void exchange(String onTrueMessage, String onFalseMessage, Exchange exchange) {
@@ -96,15 +94,15 @@ public interface SpeakingScript extends MessagingScript {
     // =================================================================================================================
 
     default void exchange(String onTrueMessage, String onFalseMessage, int money, int... itemIdAndCount) {
-        exchange(()->say(onTrueMessage), ()->say(onFalseMessage), money, itemIdAndCount);
+        exchange(() -> say(onTrueMessage), () -> say(onFalseMessage), money, itemIdAndCount);
     }
 
     default void exchange(String onFalseMessage, int money, int... itemIdAndCount) {
-        exchange(()->say(onFalseMessage), money, itemIdAndCount);
+        exchange(() -> say(onFalseMessage), money, itemIdAndCount);
     }
 
     default void exchange(BasicScriptAction onFalse, int money, int... itemIdAndCount) {
-        exchange(()->{}, onFalse, money, itemIdAndCount);
+        exchange(() -> {}, onFalse, money, itemIdAndCount);
     }
 
     default void exchange(BasicScriptAction onTrue, BasicScriptAction onFalse, int money, int... itemIdAndCount) {
@@ -192,11 +190,11 @@ public interface SpeakingScript extends MessagingScript {
     }
 
     default void askYesNo(String message, BasicScriptAction onYes, String... noMsg) {
-        ScriptAPI.askYesNo(this, message, onYes, ()->say(noMsg));
+        ScriptAPI.askYesNo(this, message, onYes, () -> say(noMsg));
     }
 
     default void askYesNo(String message, BasicScriptAction onYes, Collection<SayMessage> noMsg) {
-        ScriptAPI.askYesNo(this, message, onYes, ()->say(noMsg));
+        ScriptAPI.askYesNo(this, message, onYes, () -> say(noMsg));
     }
 
     // =================================================================================================================
@@ -212,7 +210,7 @@ public interface SpeakingScript extends MessagingScript {
     // =================================================================================================================
 
     default IntegerActionChain askMenu(int speakerTemplateId, int param, String prompt, String... menuItems) {
-        return askMenu( speakerTemplateId, param, prompt, List.of(menuItems));
+        return askMenu(speakerTemplateId, param, prompt, List.of(menuItems));
     }
 
     default IntegerActionChain askMenu(int speakerTemplateId, int param, String prompt, Collection<String> menuItems) {
@@ -242,6 +240,7 @@ public interface SpeakingScript extends MessagingScript {
     default void askMenu(String prompt, MenuItem... options) {
         ScriptAPI.askMenu(this, prompt, List.of(options));
     }
+
     default void askMenu(String prompt, List<MenuItem> options) {
         ScriptAPI.askMenu(this, prompt, options);
     }
@@ -296,6 +295,16 @@ public interface SpeakingScript extends MessagingScript {
 
     default StringActionChain askText(String message) {
         return ScriptAPI.askText(this, message);
+    }
+
+    // =================================================================================================================
+
+    default StringActionChain askSpeedQuiz(int type, int answer, int correct, int remaining, int remainInitialQuiz) {
+        return ScriptAPI.askSpeedQuiz(this, type, answer, correct, remaining, remainInitialQuiz);
+    }
+
+    default StringActionChain endSpeedQuiz() {
+        return ScriptAPI.askSpeedQuiz(this);
     }
 
     // =================================================================================================================

--- a/src/main/java/moe/maple/api/script/model/messenger/ask/AskSpeedQuizMessenger.java
+++ b/src/main/java/moe/maple/api/script/model/messenger/ask/AskSpeedQuizMessenger.java
@@ -30,7 +30,7 @@ public interface AskSpeedQuizMessenger<User> extends ScriptMessenger {
     /* This is...a big one. */
     void send(UserObject<User> userObject, int speakerType, int speakerTemplateId, int param, int type, int answer, int correct, int remaining, int remainInitialQuiz, String title, String problemText, String hintText, short min, short max);
     default void send(UserObject<User> userObject, int speakerTemplateId, int param, int type, int answer, int correct, int remaining, int remainInitialQuiz, String title, String problemText, String hintText, short min, short max) {
-        send(userObject, 0, param, type, answer, correct, remaining, remainInitialQuiz, title, problemText, hintText, min, max);
+        send(userObject, 0, speakerTemplateId, param, type, answer, correct, remaining, remainInitialQuiz, title, problemText, hintText, min, max);
     }
 
 }


### PR DESCRIPTION
-Remember to NOT decode the action byte for askSpeedQuiz. Only decode the type byte then the response (string)
-Lots of these args (like title, hint, etc) don't seem to be used (in v83 at least?). Or my source is just missing the bytes.
-askSpeedQuiz returns a StringActionChain so the scripts can do whatever they want with the user's answer (e.g. decide upon case sensitivity, log incorrect answers, etc)